### PR TITLE
Fix test in get() for defined result

### DIFF
--- a/src/Control/Monad/Eff/Ractive/Ractive.js
+++ b/src/Control/Monad/Eff/Ractive/Ractive.js
@@ -121,7 +121,7 @@ var get = function(selector){
   return function(ractive){
     return function(){
       var data = ractive.get(selector);
-      if(data){
+      if(typeof data != 'undefined'){
         return Data_Maybe.Just.create(data);
       }else{
         return Data_Maybe.Nothing.value;

--- a/test/Test.Main.purs
+++ b/test/Test.Main.purs
@@ -1,14 +1,15 @@
 module Test.Main where
 
-import Prelude (..)
-import Data.Maybe (..)
-import Control.Monad.Eff (..)
-import Control.Monad.Eff.Exception (..)
-import Control.Monad.Eff.Console (..)
-import Control.Monad.Eff.Ractive (..)
-import Control.Monad.Eff.Random (..)
-import Debug.Trace (..)
-import Test.QuickCheck (..)
+import Prelude                     (bind, Unit, (++), (==))
+import Data.Maybe                  (Maybe(..))
+import Control.Monad.Eff           (Eff)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Console   (CONSOLE, log)
+import Control.Monad.Eff.Ractive   (RactiveM, Data(..), RactiveEff, ractive,
+                                    set, observe, get, subtract)
+import Control.Monad.Eff.Random    (RANDOM)
+import Debug.Trace                 (traceA)
+import Test.QuickCheck             (quickCheck)
 
 foreign import data DOMNode :: *
 foreign import data DOMEff  :: !
@@ -45,11 +46,13 @@ main = do
 
        traceA "[TESTING] add() and subtract()"
 
+       cntr0 <- get "counter" ract
        (Control.Monad.Eff.Ractive.add "counter" (Just 5.0) Nothing ract)
        cntr1 <- (get "counter" ract)
        (subtract "counter" (Just 1.0) Nothing ract)
        cntr2 <- (get "counter" ract)
        -- | test add() / subtract()
+       quickCheck (cntr0 == (Just 0))
        quickCheck (cntr1 == (Just 5.0))
        quickCheck (cntr2 == (Just 4.0))
 
@@ -58,6 +61,8 @@ main = do
        m <- (get "message" ract)
        -- | test get()
        quickCheck (m == (Just "HELLO WORLD!"))
+       missing <- get "missing" ract :: RactiveEff (Maybe String)
+       quickCheck (missing == Nothing)
 
        traceA "[TESTING] observe()"
        (observe "message" (\n o kp -> log ("observe(): " ++ n)) Nothing ract)


### PR DESCRIPTION
This fixes a problem in `get()`, which returns `Nothing` when the value is zero or any other javascript false value.

I have also added tests for both cases, ie both when the value is defined and false, and when the value is really undefined.  I have also changed the imports in the test module, since they didn't compile.

By the way, would it be a good idea to allow issue tracking on your fork (Settings tab, Features, Issues)?  I would probably have started this discussion as an issue if it had been possible!
